### PR TITLE
Add generate utoken call

### DIFF
--- a/lib/yotpo/api/oauth.rb
+++ b/lib/yotpo/api/oauth.rb
@@ -1,5 +1,15 @@
 module Yotpo
   module Oauth
+
+    def generate_token(params)
+      request = {
+        client_id: params[:client_id],
+        client_secret: params[:client_secret],
+        grant_type: params[:grant_type]
+      }
+      post('/oauth/token', request)
+    end
+
     def validate_token(params)
       request = {
           token: params[:utoken],
@@ -17,5 +27,3 @@ module Yotpo
     end
   end
 end
-
-

--- a/spec/api/oauth_spec.rb
+++ b/spec/api/oauth_spec.rb
@@ -1,6 +1,24 @@
 require 'helper'
 
 describe Yotpo::Oauth do
+  describe '#generate_token' do
+    before(:all) do
+      generate_token_params = {
+        client_id: @app_key,
+        client_secret: @secret,
+        grant_type: "client_credentials"
+      }
+      VCR.use_cassette('generate_token') do
+        @response = Yotpo.generate_token(generate_token_params)
+      end
+    end
+
+    subject { @response.body }
+    it { should be_a ::Hashie::Mash }
+    it { should respond_to :access_token }
+    it { should respond_to :token_type }
+  end
+
   describe '#validate_token' do
     before(:all) do
       validate_token_params = {

--- a/spec/cassettes/generate_token.yml
+++ b/spec/cassettes/generate_token.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.yotpo.com/oauth/token
+    body:
+      encoding: UTF-8
+      string: '{"client_id":"3ovRYNIb6OIAI0ddS7EfpYkHpi0oTKl6bj82Vjiy","client_secret":"ZeAbRfZQl8dIohaVuPiFPLbc9a0P1wdFRuOuk6ON","grant_type":"client_credentials"}'
+    headers:
+      User-Agent:
+      - Faraday v0.9.2
+      Yotpo-Api-Connector:
+      - Ruby1.0.6
+      Content-Type:
+      - application/json
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 06 Dec 2018 22:53:12 GMT
+      Etag:
+      - W/"9138ee964cc7612eb265cacfb43e051c"
+      P3p:
+      - policyref="/w3c/p3p.xml", CP="IDC DSP COR ADM DEVi TAIi PSA PSD IVAi IVDi
+        CONi HIS OUR IND CNT", CP="CAO PSA OUR"
+      Server:
+      - nginx
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Request-Id:
+      - d56fdcaa-a1e1-46d5-a6a6-f3ab9efc2bff
+      X-Runtime:
+      - '0.016792'
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Length:
+      - '81'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"access_token":"XOf40HYpiUpEyvj4nP3iYnYidq5yuCX9Gk9vXpid","token_type":"bearer"}'
+    http_version: 
+  recorded_at: Thu, 06 Dec 2018 22:53:12 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This will make our lives easier so we can just call:

`Yotpo.generate_token(params)`

when we need to generate a utoken which according to the docs should be every time we make a request or every 14 days.