### PR TITLE
CORE-1481: add is_incentivized to create review params

### DIFF
--- a/lib/yotpo/api/review.rb
+++ b/lib/yotpo/api/review.rb
@@ -42,7 +42,8 @@ module Yotpo
           user_reference: params[:user_reference],
           custom_fields: params[:custom_fields],
           iovation_fp: params[:iovation_fp],
-          override_remote_ip: params[:override_remote_ip]
+          override_remote_ip: params[:override_remote_ip],
+          is_incentivized: params[:is_incentivized]
       }
       request.delete_if { |element, value| value.nil? }
       post('/reviews/dynamic_create', request, headers)


### PR DESCRIPTION
Passes the `is_incentivized` param when creating a review. 

I've verified these changes in this [PR](https://github.com/ritual/account-manager-api/pull/5551). View that PR more details